### PR TITLE
refactor: replace hardcoded /tmp paths with OS-agnostic temp directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ cargo run --example error_handling
 - **`commit_history.rs`** - Comprehensive commit history & log operations showing all querying APIs, filtering, analysis, and advanced LogOptions usage
 - **`error_handling.rs`** - Comprehensive error handling patterns showing GitError variants, recovery strategies, and best practices
 
-All examples use temporary directories in `/tmp/` and include automatic cleanup for safe execution.
+All examples use OS-appropriate temporary directories and include automatic cleanup for safe execution.
 
 ## Testing
 
@@ -864,7 +864,7 @@ Run the test suite:
 cargo test
 ```
 
-All tests create temporary repositories in `/tmp/` and clean up after themselves.
+All tests create temporary repositories in OS-appropriate temporary directories and clean up after themselves.
 
 ## Contributing
 

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -10,37 +10,37 @@
 //! Run with: cargo run --example basic_usage
 
 use rustic_git::{Repository, Result};
+use std::env;
 use std::fs;
-use std::path::Path;
 
 fn main() -> Result<()> {
     println!("Rustic Git - Basic Usage Example\n");
 
     // Use a temporary directory for this example
-    let repo_path = "/tmp/rustic_git_basic_example";
+    let repo_path = env::temp_dir().join("rustic_git_basic_example");
 
     // Clean up any previous run
-    if Path::new(repo_path).exists() {
-        fs::remove_dir_all(repo_path).expect("Failed to clean up previous example");
+    if repo_path.exists() {
+        fs::remove_dir_all(&repo_path).expect("Failed to clean up previous example");
     }
 
-    println!("Initializing new repository at: {}", repo_path);
+    println!("Initializing new repository at: {}", repo_path.display());
 
     // Initialize a new repository
-    let repo = Repository::init(repo_path, false)?;
+    let repo = Repository::init(&repo_path, false)?;
     println!("Repository initialized successfully\n");
 
     // Create some example files
     println!("Creating example files...");
-    fs::create_dir_all(format!("{}/src", repo_path))?;
+    fs::create_dir_all(repo_path.join("src"))?;
 
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         "# My Awesome Project\n\nThis is a demo project for rustic-git!\n",
     )?;
 
     fs::write(
-        format!("{}/src/main.rs", repo_path),
+        repo_path.join("src/main.rs"),
         r#"fn main() {
     println!("Hello from rustic-git example!");
 }
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     )?;
 
     fs::write(
-        format!("{}/src/lib.rs", repo_path),
+        repo_path.join("src/lib.rs"),
         "// Library code goes here\npub fn hello() -> &'static str {\n    \"Hello, World!\"\n}\n",
     )?;
 
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
 
     // Clean up
     println!("Cleaning up example repository...");
-    fs::remove_dir_all(repo_path)?;
+    fs::remove_dir_all(&repo_path)?;
     println!("Example completed successfully!");
 
     Ok(())

--- a/examples/branch_operations.rs
+++ b/examples/branch_operations.rs
@@ -1,25 +1,20 @@
 use rustic_git::{Repository, Result};
-use std::fs;
-use std::path::Path;
+use std::{env, fs};
 
 fn main() -> Result<()> {
-    let test_path = "/tmp/rustic_git_branch_example";
+    let test_path = env::temp_dir().join("rustic_git_branch_example");
 
     // Clean up if exists
-    if Path::new(test_path).exists() {
-        fs::remove_dir_all(test_path).unwrap();
+    if test_path.exists() {
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     // Create a test repository
-    let repo = Repository::init(test_path, false)?;
-    println!("Created repository at: {}", test_path);
+    let repo = Repository::init(&test_path, false)?;
+    println!("Created repository at: {}", test_path.display());
 
     // Create initial commit so we have a valid HEAD
-    fs::write(
-        format!("{}/README.md", test_path),
-        "# Branch Operations Demo\n",
-    )
-    .unwrap();
+    fs::write(test_path.join("README.md"), "# Branch Operations Demo\n").unwrap();
     repo.add(&["README.md"])?;
     repo.commit("Initial commit")?;
     println!("Created initial commit");
@@ -61,7 +56,7 @@ fn main() -> Result<()> {
     println!("Created and checked out: {}", dev_branch.name);
 
     // Make a commit on the new branch
-    fs::write(format!("{}/feature.txt", test_path), "New feature code\n").unwrap();
+    fs::write(test_path.join("feature.txt"), "New feature code\n").unwrap();
     repo.add(&["feature.txt"])?;
     repo.commit("Add new feature")?;
     println!("Made commit on develop branch");
@@ -139,7 +134,7 @@ fn main() -> Result<()> {
     println!("\nFinal branch count: {}", final_branches.len());
 
     // Clean up
-    fs::remove_dir_all(test_path).unwrap();
+    fs::remove_dir_all(&test_path).unwrap();
     println!("\nCleaned up test repository");
 
     Ok(())

--- a/examples/commit_history.rs
+++ b/examples/commit_history.rs
@@ -1,26 +1,25 @@
 use chrono::{Duration, Utc};
 use rustic_git::{LogOptions, Repository, Result};
-use std::fs;
-use std::path::Path;
+use std::{env, fs};
 
 fn main() -> Result<()> {
-    let test_path = "/tmp/rustic_git_commit_history_example";
+    let test_path = env::temp_dir().join("rustic_git_commit_history_example");
 
     // Clean up if exists
-    if Path::new(test_path).exists() {
-        fs::remove_dir_all(test_path).unwrap();
+    if test_path.exists() {
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     // Create a test repository
-    let repo = Repository::init(test_path, false)?;
-    println!("Created repository at: {}", test_path);
+    let repo = Repository::init(&test_path, false)?;
+    println!("Created repository at: {}", test_path.display());
 
     // Create several commits to build history
     println!("\n=== Building Commit History ===");
 
     // First commit
     fs::write(
-        format!("{}/README.md", test_path),
+        test_path.join("README.md"),
         "# Commit History Demo\n\nA demonstration of rustic-git log functionality.",
     )
     .unwrap();
@@ -29,9 +28,9 @@ fn main() -> Result<()> {
     println!("Created commit 1: {} - Initial commit", commit1.short());
 
     // Second commit
-    fs::create_dir_all(format!("{}/src", test_path)).unwrap();
+    fs::create_dir_all(test_path.join("src")).unwrap();
     fs::write(
-        format!("{}/src/main.rs", test_path),
+        test_path.join("src/main.rs"),
         "fn main() {\n    println!(\"Hello, world!\");\n}",
     )
     .unwrap();
@@ -41,7 +40,7 @@ fn main() -> Result<()> {
 
     // Third commit
     fs::write(
-        format!("{}/src/lib.rs", test_path),
+        test_path.join("src/lib.rs"),
         "pub fn greet(name: &str) -> String {\n    format!(\"Hello, {}!\", name)\n}",
     )
     .unwrap();
@@ -51,7 +50,7 @@ fn main() -> Result<()> {
 
     // Fourth commit
     fs::write(
-        format!("{}/Cargo.toml", test_path),
+        test_path.join("Cargo.toml"),
         "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"",
     )
     .unwrap();
@@ -61,7 +60,7 @@ fn main() -> Result<()> {
 
     // Fifth commit - bug fix
     fs::write(
-        format!("{}/src/main.rs", test_path),
+        test_path.join("src/main.rs"),
         "fn main() {\n    println!(\"Hello, rustic-git!\");\n}",
     )
     .unwrap();
@@ -70,7 +69,7 @@ fn main() -> Result<()> {
     println!("Created commit 5: {} - Fix greeting", commit5.short());
 
     // Sixth commit - documentation
-    fs::write(format!("{}/README.md", test_path), "# Commit History Demo\n\nA demonstration of rustic-git log functionality.\n\n## Features\n\n- Greeting functionality\n- Command line interface\n").unwrap();
+    fs::write(test_path.join("README.md"), "# Commit History Demo\n\nA demonstration of rustic-git log functionality.\n\n## Features\n\n- Greeting functionality\n- Command line interface\n").unwrap();
     repo.add(&["README.md"])?;
     let commit6 = repo.commit("Update README with features section")?;
     println!("Created commit 6: {} - Update README", commit6.short());
@@ -292,7 +291,7 @@ fn main() -> Result<()> {
     println!("\n=== Summary ===");
 
     println!("Commit history demonstration completed!");
-    println!("  Repository: {}", test_path);
+    println!("  Repository: {}", test_path.display());
     println!("  Total commits analyzed: {}", all_commits.len());
     println!("  Hash examples:");
     for commit in all_commits.iter().take(3) {
@@ -301,7 +300,7 @@ fn main() -> Result<()> {
     }
 
     // Clean up
-    fs::remove_dir_all(test_path).unwrap();
+    fs::remove_dir_all(&test_path).unwrap();
     println!("\nCleaned up test repository");
 
     Ok(())

--- a/examples/commit_workflows.rs
+++ b/examples/commit_workflows.rs
@@ -10,37 +10,36 @@
 //! Run with: cargo run --example commit_workflows
 
 use rustic_git::{Hash, Repository, Result};
-use std::fs;
-use std::path::Path;
+use std::{env, fs};
 
 fn main() -> Result<()> {
     println!("Rustic Git - Commit Workflows Example\n");
 
-    let repo_path = "/tmp/rustic_git_commit_example";
+    let repo_path = env::temp_dir().join("rustic_git_commit_example");
 
     // Clean up any previous run
-    if Path::new(repo_path).exists() {
-        fs::remove_dir_all(repo_path).expect("Failed to clean up previous example");
+    if repo_path.exists() {
+        fs::remove_dir_all(&repo_path).expect("Failed to clean up previous example");
     }
 
     // Initialize repository
     println!("Setting up repository for commit demonstrations...");
-    let repo = Repository::init(repo_path, false)?;
+    let repo = Repository::init(&repo_path, false)?;
     println!("Repository initialized\n");
 
     println!("=== Basic Commit Operations ===\n");
 
     // Create initial files
     println!("Creating initial project files...");
-    fs::create_dir_all(format!("{}/src", repo_path))?;
+    fs::create_dir_all(repo_path.join("src"))?;
 
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         "# Commit Demo Project\n\nThis project demonstrates commit workflows with rustic-git.\n",
     )?;
 
     fs::write(
-        format!("{}/src/main.rs", repo_path),
+        repo_path.join("src/main.rs"),
         r#"fn main() {
     println!("Hello, Commit Demo!");
 }
@@ -48,7 +47,7 @@ fn main() -> Result<()> {
     )?;
 
     fs::write(
-        format!("{}/Cargo.toml", repo_path),
+        repo_path.join("Cargo.toml"),
         r#"[package]
 name = "commit-demo"
 version = "0.1.0"
@@ -109,10 +108,10 @@ edition = "2021"
 
     // Create more files to commit with custom author
     println!("Adding features for custom author commit...");
-    fs::create_dir_all(format!("{}/tests", repo_path))?;
+    fs::create_dir_all(repo_path.join("tests"))?;
 
     fs::write(
-        format!("{}/src/lib.rs", repo_path),
+        repo_path.join("src/lib.rs"),
         r#"//! Commit demo library
 
 pub fn greet(name: &str) -> String {
@@ -132,7 +131,7 @@ mod tests {
     )?;
 
     fs::write(
-        format!("{}/tests/integration_test.rs", repo_path),
+        repo_path.join("tests/integration_test.rs"),
         r#"use commit_demo::greet;
 
 #[test]
@@ -166,7 +165,7 @@ fn test_integration() {
     // Commit 3: Update version
     println!("Step 1: Update version information...");
     fs::write(
-        format!("{}/Cargo.toml", repo_path),
+        repo_path.join("Cargo.toml"),
         r#"[package]
 name = "commit-demo"
 version = "0.2.0"
@@ -182,7 +181,7 @@ description = "A demo project for commit workflows"
     // Commit 4: Add documentation
     println!("Step 2: Add documentation...");
     fs::write(
-        format!("{}/CHANGELOG.md", repo_path),
+        repo_path.join("CHANGELOG.md"),
         r#"# Changelog
 
 ## [0.2.0] - 2024-01-01
@@ -210,7 +209,7 @@ description = "A demo project for commit workflows"
     // Commit 5: Final polish
     println!("Step 3: Final polish...");
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         r#"# Commit Demo Project
 
 This project demonstrates commit workflows with rustic-git.
@@ -298,10 +297,7 @@ See CHANGELOG.md for version history.
     println!("\nTesting commit with empty message:");
 
     // Create a change to commit
-    fs::write(
-        format!("{}/temp_for_empty_message.txt", repo_path),
-        "temp content",
-    )?;
+    fs::write(repo_path.join("temp_for_empty_message.txt"), "temp content")?;
     repo.add(&["temp_for_empty_message.txt"])?;
 
     match repo.commit("") {
@@ -336,7 +332,7 @@ See CHANGELOG.md for version history.
 
     // Clean up
     println!("\nCleaning up example repository...");
-    fs::remove_dir_all(repo_path)?;
+    fs::remove_dir_all(&repo_path)?;
     println!("Commit workflows example completed!");
 
     Ok(())

--- a/examples/config_operations.rs
+++ b/examples/config_operations.rs
@@ -9,24 +9,23 @@
 //! Run with: cargo run --example config_operations
 
 use rustic_git::{Repository, Result};
-use std::fs;
-use std::path::Path;
+use std::{env, fs};
 
 fn main() -> Result<()> {
     println!("Rustic Git - Repository Configuration Operations Example\n");
 
     // Use a temporary directory for this example
-    let repo_path = "/tmp/rustic_git_config_example";
+    let repo_path = env::temp_dir().join("rustic_git_config_example");
 
     // Clean up any previous run
-    if Path::new(repo_path).exists() {
-        fs::remove_dir_all(repo_path).expect("Failed to clean up previous example");
+    if repo_path.exists() {
+        fs::remove_dir_all(&repo_path).expect("Failed to clean up previous example");
     }
 
-    println!("Initializing new repository at: {}", repo_path);
+    println!("Initializing new repository at: {}", repo_path.display());
 
     // Initialize a new repository
-    let repo = Repository::init(repo_path, false)?;
+    let repo = Repository::init(&repo_path, false)?;
 
     // ==================== USER CONFIGURATION ====================
 
@@ -77,7 +76,7 @@ fn main() -> Result<()> {
     println!("\n[COMMIT] Testing configuration with commit operations...");
 
     // Create a test file
-    let test_file_path = format!("{}/test.txt", repo_path);
+    let test_file_path = repo_path.join("test.txt");
     fs::write(
         &test_file_path,
         "Hello from rustic-git configuration example!",
@@ -185,7 +184,7 @@ fn main() -> Result<()> {
 
     // Create another commit with the team configuration
     fs::write(
-        format!("{}/team.md", repo_path),
+        repo_path.join("team.md"),
         "# Team Development\n\nThis repository is configured for team development.",
     )?;
     repo.add(&["team.md"])?;
@@ -202,7 +201,7 @@ fn main() -> Result<()> {
     // ==================== CLEANUP ====================
 
     println!("\n[CLEANUP] Cleaning up...");
-    fs::remove_dir_all(repo_path).expect("Failed to clean up example");
+    fs::remove_dir_all(&repo_path).expect("Failed to clean up example");
     println!("Example completed successfully!");
 
     Ok(())

--- a/examples/repository_operations.rs
+++ b/examples/repository_operations.rs
@@ -9,33 +9,36 @@
 //! Run with: cargo run --example repository_operations
 
 use rustic_git::{GitError, Repository, Result};
+use std::env;
 use std::fs;
-use std::path::Path;
 
 fn main() -> Result<()> {
     println!("Rustic Git - Repository Operations Example\n");
 
-    let base_path = "/tmp/rustic_git_repo_example";
-    let regular_repo_path = format!("{}/regular", base_path);
-    let bare_repo_path = format!("{}/bare", base_path);
-    let nonexistent_path = format!("{}/nonexistent", base_path);
+    let base_path = env::temp_dir().join("rustic_git_repo_example");
+    let regular_repo_path = base_path.join("regular");
+    let bare_repo_path = base_path.join("bare");
+    let nonexistent_path = base_path.join("nonexistent");
 
     // Clean up any previous runs
-    if Path::new(base_path).exists() {
-        fs::remove_dir_all(base_path).expect("Failed to clean up previous example");
+    if base_path.exists() {
+        fs::remove_dir_all(&base_path).expect("Failed to clean up previous example");
     }
-    fs::create_dir_all(base_path)?;
+    fs::create_dir_all(&base_path)?;
 
     println!("=== Repository Initialization ===\n");
 
     // 1. Initialize a regular repository
     println!("Initializing regular repository...");
     let regular_repo = Repository::init(&regular_repo_path, false)?;
-    println!("Regular repository created at: {}", regular_repo_path);
+    println!(
+        "Regular repository created at: {}",
+        regular_repo_path.display()
+    );
     println!("   Repository path: {:?}", regular_repo.repo_path());
 
     // Verify it's a git repo by checking for .git directory
-    if Path::new(&format!("{}/.git", regular_repo_path)).exists() {
+    if regular_repo_path.join(".git").exists() {
         println!("   .git directory found");
     }
     println!();
@@ -43,14 +46,14 @@ fn main() -> Result<()> {
     // 2. Initialize a bare repository
     println!("Initializing bare repository...");
     let bare_repo = Repository::init(&bare_repo_path, true)?;
-    println!("Bare repository created at: {}", bare_repo_path);
+    println!("Bare repository created at: {}", bare_repo_path.display());
     println!("   Repository path: {:?}", bare_repo.repo_path());
 
     // Verify bare repo structure (has HEAD, objects, etc. directly)
-    if Path::new(&format!("{}/HEAD", bare_repo_path)).exists() {
+    if bare_repo_path.join("HEAD").exists() {
         println!("   HEAD file found (bare repository structure)");
     }
-    if Path::new(&format!("{}/objects", bare_repo_path)).exists() {
+    if bare_repo_path.join("objects").exists() {
         println!("   objects directory found");
     }
     println!();
@@ -116,7 +119,7 @@ fn main() -> Result<()> {
     println!();
 
     // 6. Try to open a regular file as a repository
-    let fake_repo_path = format!("{}/fake.txt", base_path);
+    let fake_repo_path = base_path.join("fake.txt");
     fs::write(&fake_repo_path, "This is not a git repository")?;
 
     println!("Attempting to open regular file as repository...");
@@ -178,7 +181,7 @@ fn main() -> Result<()> {
 
     // Clean up
     println!("Cleaning up example repositories...");
-    fs::remove_dir_all(base_path)?;
+    fs::remove_dir_all(&base_path)?;
     println!("Repository operations example completed!");
 
     Ok(())

--- a/examples/staging_operations.rs
+++ b/examples/staging_operations.rs
@@ -9,37 +9,36 @@
 //! Run with: cargo run --example staging_operations
 
 use rustic_git::{IndexStatus, Repository, Result, WorktreeStatus};
-use std::fs;
-use std::path::Path;
+use std::{env, fs};
 
 fn main() -> Result<()> {
     println!("Rustic Git - Staging Operations Example\n");
 
-    let repo_path = "/tmp/rustic_git_staging_example";
+    let repo_path = env::temp_dir().join("rustic_git_staging_example");
 
     // Clean up any previous run
-    if Path::new(repo_path).exists() {
-        fs::remove_dir_all(repo_path).expect("Failed to clean up previous example");
+    if repo_path.exists() {
+        fs::remove_dir_all(&repo_path).expect("Failed to clean up previous example");
     }
 
     // Initialize repository and create initial commit
     println!("Setting up repository with initial files...");
-    let repo = Repository::init(repo_path, false)?;
+    let repo = Repository::init(&repo_path, false)?;
 
     // Create initial files
-    fs::create_dir_all(format!("{}/src", repo_path))?;
-    fs::create_dir_all(format!("{}/docs", repo_path))?;
+    fs::create_dir_all(repo_path.join("src"))?;
+    fs::create_dir_all(repo_path.join("docs"))?;
 
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         "# Staging Demo\nOriginal content",
     )?;
     fs::write(
-        format!("{}/src/main.rs", repo_path),
+        repo_path.join("src/main.rs"),
         "fn main() { println!(\"v1\"); }",
     )?;
     fs::write(
-        format!("{}/src/lib.rs", repo_path),
+        repo_path.join("src/lib.rs"),
         "pub fn version() -> &'static str { \"1.0\" }",
     )?;
 
@@ -52,17 +51,17 @@ fn main() -> Result<()> {
 
     // Create some new files and modify existing ones
     println!("Creating new files and modifying existing ones...");
-    fs::write(format!("{}/new_file1.txt", repo_path), "New file 1 content")?;
-    fs::write(format!("{}/new_file2.txt", repo_path), "New file 2 content")?;
-    fs::write(format!("{}/docs/guide.md", repo_path), "# User Guide")?;
+    fs::write(repo_path.join("new_file1.txt"), "New file 1 content")?;
+    fs::write(repo_path.join("new_file2.txt"), "New file 2 content")?;
+    fs::write(repo_path.join("docs/guide.md"), "# User Guide")?;
 
     // Modify existing files
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         "# Staging Demo\nUpdated content!",
     )?;
     fs::write(
-        format!("{}/src/main.rs", repo_path),
+        repo_path.join("src/main.rs"),
         "fn main() { println!(\"v2 - updated!\"); }",
     )?;
 
@@ -117,13 +116,13 @@ fn main() -> Result<()> {
     // Create more files to demonstrate add_all()
     println!("Creating additional files for add_all() demo...");
     fs::write(
-        format!("{}/config.toml", repo_path),
+        repo_path.join("config.toml"),
         "[package]\nname = \"example\"",
     )?;
-    fs::write(format!("{}/src/utils.rs", repo_path), "pub fn helper() {}")?;
-    fs::create_dir_all(format!("{}/tests", repo_path))?;
+    fs::write(repo_path.join("src/utils.rs"), "pub fn helper() {}")?;
+    fs::create_dir_all(repo_path.join("tests"))?;
     fs::write(
-        format!("{}/tests/integration.rs", repo_path),
+        repo_path.join("tests/integration.rs"),
         "#[test]\nfn test_basic() {}",
     )?;
 
@@ -155,23 +154,20 @@ fn main() -> Result<()> {
     println!("Setting up files for add_update() demonstration...");
 
     // Create new untracked files (these should NOT be staged by add_update)
-    fs::write(format!("{}/untracked1.txt", repo_path), "This is untracked")?;
-    fs::write(
-        format!("{}/untracked2.txt", repo_path),
-        "Another untracked file",
-    )?;
+    fs::write(repo_path.join("untracked1.txt"), "This is untracked")?;
+    fs::write(repo_path.join("untracked2.txt"), "Another untracked file")?;
 
     // Modify existing tracked files (these SHOULD be staged by add_update)
     fs::write(
-        format!("{}/README.md", repo_path),
+        repo_path.join("README.md"),
         "# Staging Demo\nContent updated again for add_update demo!",
     )?;
     fs::write(
-        format!("{}/src/lib.rs", repo_path),
+        repo_path.join("src/lib.rs"),
         "pub fn version() -> &'static str { \"2.0\" }",
     )?;
     fs::write(
-        format!("{}/config.toml", repo_path),
+        repo_path.join("config.toml"),
         "[package]\nname = \"example\"\nversion = \"0.2.0\"",
     )?;
 
@@ -244,7 +240,7 @@ fn main() -> Result<()> {
 
     // Clean up
     println!("\nCleaning up example repository...");
-    fs::remove_dir_all(repo_path)?;
+    fs::remove_dir_all(&repo_path)?;
     println!("Staging operations example completed!");
 
     Ok(())

--- a/examples/status_checking.rs
+++ b/examples/status_checking.rs
@@ -9,22 +9,22 @@
 //! Run with: cargo run --example status_checking
 
 use rustic_git::{IndexStatus, Repository, Result, WorktreeStatus};
+use std::env;
 use std::fs;
-use std::path::Path;
 
 fn main() -> Result<()> {
     println!("Rustic Git - Status Checking Example\n");
 
-    let repo_path = "/tmp/rustic_git_status_example";
+    let repo_path = env::temp_dir().join("rustic_git_status_example");
 
     // Clean up any previous run
-    if Path::new(repo_path).exists() {
-        fs::remove_dir_all(repo_path).expect("Failed to clean up previous example");
+    if repo_path.exists() {
+        fs::remove_dir_all(&repo_path).expect("Failed to clean up previous example");
     }
 
     // Initialize repository
     println!("Setting up repository for status demonstration...");
-    let repo = Repository::init(repo_path, false)?;
+    let repo = Repository::init(&repo_path, false)?;
 
     println!("=== Clean Repository Status ===\n");
 
@@ -40,26 +40,17 @@ fn main() -> Result<()> {
     println!("Creating test files...");
 
     // Create some files that will be untracked
-    fs::write(
-        format!("{}/untracked1.txt", repo_path),
-        "This file is untracked",
-    )?;
-    fs::write(
-        format!("{}/untracked2.txt", repo_path),
-        "Another untracked file",
-    )?;
+    fs::write(repo_path.join("untracked1.txt"), "This file is untracked")?;
+    fs::write(repo_path.join("untracked2.txt"), "Another untracked file")?;
 
     // Create a .gitignore to demonstrate ignored files
-    fs::write(
-        format!("{}/.gitignore", repo_path),
-        "*.log\n*.tmp\n/temp/\n",
-    )?;
+    fs::write(repo_path.join(".gitignore"), "*.log\n*.tmp\n/temp/\n")?;
 
     // Create files that will be ignored
-    fs::write(format!("{}/debug.log", repo_path), "Log file content")?;
-    fs::write(format!("{}/cache.tmp", repo_path), "Temporary file")?;
-    fs::create_dir_all(format!("{}/temp", repo_path))?;
-    fs::write(format!("{}/temp/data.txt", repo_path), "Temp data")?;
+    fs::write(repo_path.join("debug.log"), "Log file content")?;
+    fs::write(repo_path.join("cache.tmp"), "Temporary file")?;
+    fs::create_dir_all(repo_path.join("temp"))?;
+    fs::write(repo_path.join("temp/data.txt"), "Temp data")?;
 
     println!("Created test files");
 
@@ -100,11 +91,11 @@ fn main() -> Result<()> {
 
     // Modify existing tracked files
     fs::write(
-        format!("{}/untracked1.txt", repo_path),
+        repo_path.join("untracked1.txt"),
         "This file has been MODIFIED!",
     )?;
     fs::write(
-        format!("{}/.gitignore", repo_path),
+        repo_path.join(".gitignore"),
         "*.log\n*.tmp\n/temp/\n# Added comment\n",
     )?;
     println!("Modified untracked1.txt and .gitignore");
@@ -249,7 +240,7 @@ fn main() -> Result<()> {
 
     // Clean up
     println!("\nCleaning up example repository...");
-    fs::remove_dir_all(repo_path)?;
+    fs::remove_dir_all(&repo_path)?;
     println!("Status checking example completed!");
 
     Ok(())

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -60,31 +60,32 @@ impl Repository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    fn create_test_repo(path: &str) -> Repository {
+    fn create_test_repo(path: &PathBuf) -> Repository {
         // Clean up if exists
-        if Path::new(path).exists() {
+        if path.exists() {
             fs::remove_dir_all(path).unwrap();
         }
 
         Repository::init(path, false).unwrap()
     }
 
-    fn create_test_file(repo_path: &str, filename: &str, content: &str) {
-        let file_path = format!("{}/{}", repo_path, filename);
+    fn create_test_file(repo_path: &Path, filename: &str, content: &str) {
+        let file_path = repo_path.join(filename);
         fs::write(file_path, content).unwrap();
     }
 
     #[test]
     fn test_add_specific_files() {
-        let test_path = "/tmp/test_add_repo";
-        let repo = create_test_repo(test_path);
+        let test_path = env::temp_dir().join("test_add_repo");
+        let repo = create_test_repo(&test_path);
 
         // Create some test files
-        create_test_file(test_path, "file1.txt", "content 1");
-        create_test_file(test_path, "file2.txt", "content 2");
+        create_test_file(&test_path, "file1.txt", "content 1");
+        create_test_file(&test_path, "file2.txt", "content 2");
 
         // Add specific files
         let result = repo.add(&["file1.txt"]);
@@ -100,18 +101,18 @@ mod tests {
         assert!(added_files.contains(&"file1.txt"));
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_add_multiple_files() {
-        let test_path = "/tmp/test_add_multiple_repo";
-        let repo = create_test_repo(test_path);
+        let test_path = env::temp_dir().join("test_add_multiple_repo");
+        let repo = create_test_repo(&test_path);
 
         // Create test files
-        create_test_file(test_path, "file1.txt", "content 1");
-        create_test_file(test_path, "file2.txt", "content 2");
-        create_test_file(test_path, "file3.txt", "content 3");
+        create_test_file(&test_path, "file1.txt", "content 1");
+        create_test_file(&test_path, "file2.txt", "content 2");
+        create_test_file(&test_path, "file3.txt", "content 3");
 
         // Add multiple files
         let result = repo.add(&["file1.txt", "file2.txt"]);
@@ -129,19 +130,19 @@ mod tests {
         assert_eq!(added_files.len(), 2);
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_add_all() {
-        let test_path = "/tmp/test_add_all_repo";
-        let repo = create_test_repo(test_path);
+        let test_path = env::temp_dir().join("test_add_all_repo");
+        let repo = create_test_repo(&test_path);
 
         // Create test files
-        create_test_file(test_path, "file1.txt", "content 1");
-        create_test_file(test_path, "file2.txt", "content 2");
-        fs::create_dir(format!("{}/subdir", test_path)).unwrap();
-        create_test_file(test_path, "subdir/file3.txt", "content 3");
+        create_test_file(&test_path, "file1.txt", "content 1");
+        create_test_file(&test_path, "file2.txt", "content 2");
+        fs::create_dir(test_path.join("subdir")).unwrap();
+        create_test_file(&test_path, "subdir/file3.txt", "content 3");
 
         // Add all files
         let result = repo.add_all();
@@ -159,32 +160,32 @@ mod tests {
         assert!(added_files.contains(&"subdir/file3.txt"));
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_add_empty_paths() {
-        let test_path = "/tmp/test_add_empty_repo";
-        let repo = create_test_repo(test_path);
+        let test_path = env::temp_dir().join("test_add_empty_repo");
+        let repo = create_test_repo(&test_path);
 
         // Adding empty paths should succeed without error
         let result = repo.add::<&str>(&[]);
         assert!(result.is_ok());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_add_nonexistent_file() {
-        let test_path = "/tmp/test_add_nonexistent_repo";
-        let repo = create_test_repo(test_path);
+        let test_path = env::temp_dir().join("test_add_nonexistent_repo");
+        let repo = create_test_repo(&test_path);
 
         // Adding non-existent file should fail
         let result = repo.add(&["nonexistent.txt"]);
         assert!(result.is_err());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -29,18 +29,18 @@ impl<'a> RepoConfig<'a> {
     ///
     /// ```rust
     /// use rustic_git::Repository;
-    /// use std::fs;
+    /// use std::{env, fs};
     ///
-    /// let test_path = "/tmp/config_set_user_test";
-    /// if std::path::Path::new(test_path).exists() {
-    ///     fs::remove_dir_all(test_path).unwrap();
+    /// let test_path = env::temp_dir().join("config_set_user_test");
+    /// if test_path.exists() {
+    ///     fs::remove_dir_all(&test_path).unwrap();
     /// }
     ///
-    /// let repo = Repository::init(test_path, false)?;
+    /// let repo = Repository::init(&test_path, false)?;
     /// repo.config().set_user("John Doe", "john@example.com")?;
     ///
     /// // Clean up
-    /// fs::remove_dir_all(test_path).unwrap();
+    /// fs::remove_dir_all(&test_path).unwrap();
     /// # Ok::<(), rustic_git::GitError>(())
     /// ```
     pub fn set_user(&self, name: &str, email: &str) -> Result<()> {
@@ -74,19 +74,19 @@ impl<'a> RepoConfig<'a> {
     ///
     /// ```rust
     /// use rustic_git::Repository;
-    /// use std::fs;
+    /// use std::{env, fs};
     ///
-    /// let test_path = "/tmp/config_set_test";
-    /// if std::path::Path::new(test_path).exists() {
-    ///     fs::remove_dir_all(test_path).unwrap();
+    /// let test_path = env::temp_dir().join("config_set_test");
+    /// if test_path.exists() {
+    ///     fs::remove_dir_all(&test_path).unwrap();
     /// }
     ///
-    /// let repo = Repository::init(test_path, false)?;
+    /// let repo = Repository::init(&test_path, false)?;
     /// repo.config().set("core.autocrlf", "false")?;
     /// repo.config().set("user.name", "Jane Doe")?;
     ///
     /// // Clean up
-    /// fs::remove_dir_all(test_path).unwrap();
+    /// fs::remove_dir_all(&test_path).unwrap();
     /// # Ok::<(), rustic_git::GitError>(())
     /// ```
     pub fn set(&self, key: &str, value: &str) -> Result<()> {
@@ -108,20 +108,20 @@ impl<'a> RepoConfig<'a> {
     ///
     /// ```rust
     /// use rustic_git::Repository;
-    /// use std::fs;
+    /// use std::{env, fs};
     ///
-    /// let test_path = "/tmp/config_get_test";
-    /// if std::path::Path::new(test_path).exists() {
-    ///     fs::remove_dir_all(test_path).unwrap();
+    /// let test_path = env::temp_dir().join("config_get_test");
+    /// if test_path.exists() {
+    ///     fs::remove_dir_all(&test_path).unwrap();
     /// }
     ///
-    /// let repo = Repository::init(test_path, false)?;
+    /// let repo = Repository::init(&test_path, false)?;
     /// repo.config().set("user.name", "Jane Doe")?;
     /// let name = repo.config().get("user.name")?;
     /// assert_eq!(name, "Jane Doe");
     ///
     /// // Clean up
-    /// fs::remove_dir_all(test_path).unwrap();
+    /// fs::remove_dir_all(&test_path).unwrap();
     /// # Ok::<(), rustic_git::GitError>(())
     /// ```
     pub fn get(&self, key: &str) -> Result<String> {
@@ -138,19 +138,19 @@ impl<'a> RepoConfig<'a> {
     ///
     /// ```rust
     /// use rustic_git::Repository;
-    /// use std::fs;
+    /// use std::{env, fs};
     ///
-    /// let test_path = "/tmp/config_unset_test";
-    /// if std::path::Path::new(test_path).exists() {
-    ///     fs::remove_dir_all(test_path).unwrap();
+    /// let test_path = env::temp_dir().join("config_unset_test");
+    /// if test_path.exists() {
+    ///     fs::remove_dir_all(&test_path).unwrap();
     /// }
     ///
-    /// let repo = Repository::init(test_path, false)?;
+    /// let repo = Repository::init(&test_path, false)?;
     /// repo.config().set("test.value", "temporary")?;
     /// repo.config().unset("test.value")?;
     ///
     /// // Clean up
-    /// fs::remove_dir_all(test_path).unwrap();
+    /// fs::remove_dir_all(&test_path).unwrap();
     /// # Ok::<(), rustic_git::GitError>(())
     /// ```
     pub fn unset(&self, key: &str) -> Result<()> {
@@ -162,19 +162,19 @@ impl<'a> RepoConfig<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
-    use std::path::Path;
 
     #[test]
     fn test_config_set_and_get_user() {
-        let test_path = "/tmp/test_config_user";
+        let test_path = env::temp_dir().join("test_config_user");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Set user configuration
         repo.config()
@@ -187,19 +187,19 @@ mod tests {
         assert_eq!(email, "test@example.com");
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_config_set_and_get_generic() {
-        let test_path = "/tmp/test_config_generic";
+        let test_path = env::temp_dir().join("test_config_generic");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Set generic configuration
         repo.config().set("core.autocrlf", "false").unwrap();
@@ -213,19 +213,19 @@ mod tests {
         assert_eq!(name, "Generic User");
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_config_unset() {
-        let test_path = "/tmp/test_config_unset";
+        let test_path = env::temp_dir().join("test_config_unset");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Set a test value
         repo.config().set("test.temporary", "value").unwrap();
@@ -240,38 +240,38 @@ mod tests {
         assert!(result.is_err());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_config_get_nonexistent_key() {
-        let test_path = "/tmp/test_config_nonexistent";
+        let test_path = env::temp_dir().join("test_config_nonexistent");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Try to get a non-existent key
         let result = repo.config().get("nonexistent.key");
         assert!(result.is_err());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_config_integration_with_commit() {
-        let test_path = "/tmp/test_config_commit_integration";
+        let test_path = env::temp_dir().join("test_config_commit_integration");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Configure user for commits
         repo.config()
@@ -279,7 +279,7 @@ mod tests {
             .unwrap();
 
         // Create a file and commit
-        std::fs::write(format!("{}/test.txt", test_path), "test content").unwrap();
+        std::fs::write(test_path.join("test.txt"), "test content").unwrap();
         repo.add(&["test.txt"]).unwrap();
         let hash = repo.commit("Test commit with config API").unwrap();
 
@@ -287,6 +287,6 @@ mod tests {
         assert!(!hash.as_str().is_empty());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -214,8 +214,8 @@ impl Repository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
-    use std::path::Path;
 
     #[test]
     fn test_parse_porcelain_output() {
@@ -283,22 +283,22 @@ mod tests {
 
     #[test]
     fn test_repository_status() {
-        let test_path = "/tmp/test_status_repo";
+        let test_path = env::temp_dir().join("test_status_repo");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Create a repository
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Get status of empty repository
         let status = repo.status().unwrap();
         assert!(status.is_clean());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -103,8 +103,10 @@ impl Repository {
     ///
     /// ```rust
     /// use rustic_git::Repository;
+    /// use std::env;
     ///
-    /// let repo = Repository::init("/tmp/test", false)?;
+    /// let test_path = env::temp_dir().join("test");
+    /// let repo = Repository::init(&test_path, false)?;
     /// repo.config().set_user("John Doe", "john@example.com")?;
     ///
     /// let (name, email) = repo.config().get_user()?;
@@ -120,82 +122,82 @@ impl Repository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
-    use std::path::Path;
 
     #[test]
     fn test_git_init_creates_repository() {
-        let test_path = "/tmp/test_repo";
+        let test_path = env::temp_dir().join("test_repo");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Initialize repository
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Check that .git directory was created
-        assert!(Path::new(&format!("{}/.git", test_path)).exists());
-        assert_eq!(repo.repo_path(), Path::new(test_path));
+        assert!(test_path.join(".git").exists());
+        assert_eq!(repo.repo_path(), test_path.as_path());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_git_init_bare_repository() {
-        let test_path = "/tmp/test_bare_repo";
+        let test_path = env::temp_dir().join("test_bare_repo");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Initialize bare repository
-        let repo = Repository::init(test_path, true).unwrap();
+        let repo = Repository::init(&test_path, true).unwrap();
 
         // Check that bare repo files were created (no .git subdirectory)
-        assert!(Path::new(&format!("{}/HEAD", test_path)).exists());
-        assert!(Path::new(&format!("{}/objects", test_path)).exists());
-        assert!(!Path::new(&format!("{}/.git", test_path)).exists());
-        assert_eq!(repo.repo_path(), Path::new(test_path));
+        assert!(test_path.join("HEAD").exists());
+        assert!(test_path.join("objects").exists());
+        assert!(!test_path.join(".git").exists());
+        assert_eq!(repo.repo_path(), test_path.as_path());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_open_existing_repository() {
-        let test_path = "/tmp/test_open_repo";
+        let test_path = env::temp_dir().join("test_open_repo");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // First create a repository
-        let _created_repo = Repository::init(test_path, false).unwrap();
+        let _created_repo = Repository::init(&test_path, false).unwrap();
 
         // Now open the existing repository
-        let opened_repo = Repository::open(test_path).unwrap();
-        assert_eq!(opened_repo.repo_path(), Path::new(test_path));
+        let opened_repo = Repository::open(&test_path).unwrap();
+        assert_eq!(opened_repo.repo_path(), test_path.as_path());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_open_nonexistent_path() {
-        let test_path = "/tmp/nonexistent_repo_path";
+        let test_path = env::temp_dir().join("nonexistent_repo_path");
 
         // Ensure path doesn't exist
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Try to open non-existent repository
-        let result = Repository::open(test_path);
+        let result = Repository::open(&test_path);
         assert!(result.is_err());
 
         if let Err(GitError::CommandFailed(msg)) = result {
@@ -207,16 +209,16 @@ mod tests {
 
     #[test]
     fn test_open_non_git_directory() {
-        let test_path = "/tmp/not_a_git_repo";
+        let test_path = env::temp_dir().join("not_a_git_repo");
 
         // Clean up if exists and create a regular directory
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
-        fs::create_dir(test_path).unwrap();
+        fs::create_dir(&test_path).unwrap();
 
         // Try to open directory that's not a git repository
-        let result = Repository::open(test_path);
+        let result = Repository::open(&test_path);
         assert!(result.is_err());
 
         if let Err(GitError::CommandFailed(msg)) = result {
@@ -226,46 +228,46 @@ mod tests {
         }
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_repo_path_method() {
-        let test_path = "/tmp/test_repo_path";
+        let test_path = env::temp_dir().join("test_repo_path");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Initialize repository
-        let repo = Repository::init(test_path, false).unwrap();
+        let repo = Repository::init(&test_path, false).unwrap();
 
         // Test repo_path method
-        assert_eq!(repo.repo_path(), Path::new(test_path));
+        assert_eq!(repo.repo_path(), test_path.as_path());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
     fn test_repo_path_method_after_open() {
-        let test_path = "/tmp/test_repo_path_open";
+        let test_path = env::temp_dir().join("test_repo_path_open");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
         }
 
         // Initialize and then open repository
-        let _created_repo = Repository::init(test_path, false).unwrap();
-        let opened_repo = Repository::open(test_path).unwrap();
+        let _created_repo = Repository::init(&test_path, false).unwrap();
+        let opened_repo = Repository::open(&test_path).unwrap();
 
         // Test repo_path method on opened repository
-        assert_eq!(opened_repo.repo_path(), Path::new(test_path));
+        assert_eq!(opened_repo.repo_path(), test_path.as_path());
 
         // Clean up
-        fs::remove_dir_all(test_path).unwrap();
+        fs::remove_dir_all(&test_path).unwrap();
     }
 
     #[test]
@@ -305,98 +307,98 @@ mod tests {
 
     #[test]
     fn test_init_with_relative_path() {
-        let test_path = "relative_test_repo";
+        let test_path = env::temp_dir().join("relative_test_repo");
 
         // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
-        }
-
-        let result = Repository::init(test_path, false);
-
-        if let Ok(repo) = result {
-            assert_eq!(repo.repo_path(), Path::new(test_path));
-
-            // Clean up
-            fs::remove_dir_all(test_path).unwrap();
-        }
-    }
-
-    #[test]
-    fn test_open_with_relative_path() {
-        let test_path = "relative_open_repo";
-
-        // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
-        }
-
-        // Create the repo first
-        let _created = Repository::init(test_path, false).unwrap();
-
-        // Now open with relative path
-        let result = Repository::open(test_path);
-        assert!(result.is_ok());
-
-        let repo = result.unwrap();
-        assert_eq!(repo.repo_path(), Path::new(test_path));
-
-        // Clean up
-        fs::remove_dir_all(test_path).unwrap();
-    }
-
-    #[test]
-    fn test_init_with_unicode_path() {
-        let test_path = "/tmp/测试_repo_🚀";
-
-        // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
-        }
-
-        let result = Repository::init(test_path, false);
-
-        if let Ok(repo) = result {
-            assert_eq!(repo.repo_path(), Path::new(test_path));
-
-            // Clean up
-            fs::remove_dir_all(test_path).unwrap();
-        }
-    }
-
-    #[test]
-    fn test_path_with_spaces() {
-        let test_path = "/tmp/test repo with spaces";
-
-        // Clean up if exists
-        if Path::new(test_path).exists() {
-            fs::remove_dir_all(test_path).unwrap();
-        }
-
-        let result = Repository::init(test_path, false);
-
-        if let Ok(repo) = result {
-            assert_eq!(repo.repo_path(), Path::new(test_path));
-
-            // Clean up
-            fs::remove_dir_all(test_path).unwrap();
-        }
-    }
-
-    #[test]
-    fn test_very_long_path() {
-        let long_component = "a".repeat(100);
-        let test_path = format!("/tmp/{}", long_component);
-
-        // Clean up if exists
-        if Path::new(&test_path).exists() {
+        if test_path.exists() {
             fs::remove_dir_all(&test_path).unwrap();
         }
 
         let result = Repository::init(&test_path, false);
 
         if let Ok(repo) = result {
-            assert_eq!(repo.repo_path(), Path::new(&test_path));
+            assert_eq!(repo.repo_path(), test_path.as_path());
+
+            // Clean up
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_open_with_relative_path() {
+        let test_path = env::temp_dir().join("relative_open_repo");
+
+        // Clean up if exists
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+
+        // Create the repo first
+        let _created = Repository::init(&test_path, false).unwrap();
+
+        // Now open with relative path
+        let result = Repository::open(&test_path);
+        assert!(result.is_ok());
+
+        let repo = result.unwrap();
+        assert_eq!(repo.repo_path(), test_path.as_path());
+
+        // Clean up
+        fs::remove_dir_all(&test_path).unwrap();
+    }
+
+    #[test]
+    fn test_init_with_unicode_path() {
+        let test_path = env::temp_dir().join("测试_repo_🚀");
+
+        // Clean up if exists
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+
+        let result = Repository::init(&test_path, false);
+
+        if let Ok(repo) = result {
+            assert_eq!(repo.repo_path(), test_path.as_path());
+
+            // Clean up
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_path_with_spaces() {
+        let test_path = env::temp_dir().join("test repo with spaces");
+
+        // Clean up if exists
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+
+        let result = Repository::init(&test_path, false);
+
+        if let Ok(repo) = result {
+            assert_eq!(repo.repo_path(), test_path.as_path());
+
+            // Clean up
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_very_long_path() {
+        let long_component = "a".repeat(100);
+        let test_path = env::temp_dir().join(&long_component);
+
+        // Clean up if exists
+        if test_path.exists() {
+            fs::remove_dir_all(&test_path).unwrap();
+        }
+
+        let result = Repository::init(&test_path, false);
+
+        if let Ok(repo) = result {
+            assert_eq!(repo.repo_path(), test_path.as_path());
 
             // Clean up
             fs::remove_dir_all(&test_path).unwrap();


### PR DESCRIPTION
Replace hardcoded Unix-specific /tmp/ paths with std::env::temp_dir() throughout the codebase for cross-platform compatibility. This ensures tests and examples work correctly on Windows, macOS, and Linux.

Changes:
- Update all test functions to use env::temp_dir()
- Update all example files to use OS-appropriate temp directories
- Update doctests to use env::temp_dir()
- Update README documentation to reflect OS-agnostic approach
- Replace string path concatenation with proper PathBuf operations
- Improve type safety by using &Path instead of &str in helpers